### PR TITLE
Expand plotRP() functionality

### DIFF
--- a/R/plotRP.R
+++ b/R/plotRP.R
@@ -1,25 +1,26 @@
-## plotRP(): Function to plot the RP
+## plotRP(): Function to plot the recurrence plot
 ##
 ## Arguments:
-##     RP        : the RP ngCMatrix output from crqa() function
-##     labelx    : character ; the text label of the x-axis 
-##                 (default: "Time")
-##     labely    : character ; the text label of the y-axis 
-##                 (default: "Time")
-##     labelmain : character ; main title text of the plot 
-##                 (default: "Recurrence Plot")
-##     point_col : character ; the color for the recurrent points;
-##                 may include any colors from the base R plot repertoire
-##                 (default: "black)
-##     pcex      : numeric ; the size of the recurrent points
-##                 (default: .3)
-##     pch       : numeric ; the style of the recurrent points
-##                 (default: 1)
-##     show_ticks: boolean ; whether to show x- and y-ticks or not
-##                 (default: FALSE)
-##     unit      : numeric ; gap between sample labeling on axes.
-##                 Note: only relevant if `show_ticks = TRUE`.
-##                 (default: 10)
+##     RP          : the RP ngCMatrix output from crqa() function
+##     par         : a list of parameters for the plotting, including:
+##       unit      : numeric ; gap between sample labeling on axes.
+##                   Note: only relevant if `show_ticks = TRUE`.
+##                   (default: 10)
+##       labelmain : character ; main title text of the plot 
+##                   (default: "Recurrence Plot")
+##       labelx    : character ; the text label of the x-axis 
+##                   (default: "Time")
+##       labely    : character ; the text label of the y-axis 
+##                   (default: "Time")
+##       col       : character ; the color for the recurrent points;
+##                   may include any colors from the base R plot repertoire
+##                   (default: "black)
+##       pcex      : numeric ; the size of the recurrent points
+##                   (default: .3)
+##       pch       : numeric ; the style of the recurrent points
+##                   (default: 1)
+##       show_ticks: boolean ; whether to show x- and y-ticks or not
+##                   (default: FALSE)
 ##
 ## Value:
 ##     A square plot visualizing the recurrence matrix.
@@ -28,11 +29,35 @@
 
 .packageName <- 'crqa'
 
-plotRP <- function(RP, 
-                   labelx = "Time", labely = "Time", 
-                   labelmain = "Recurrence Plot",
-                   point_col = "black", pcex = .3, pch = 1,
-                   unit = 10, show_ticks = FALSE){
+plotRP <- function(RP, par){
+  
+  # specify the space of possible parameters
+  default_par = c(labelx = "Time",
+                  labely = "Time",
+                  labelmain = "Recurrence Plot",
+                  point_col = "black",
+                  pcex = .3, 
+                  pch = 1,
+                  unit = 10,
+                  show_ticks = FALSE)
+  
+  # if no user-defined parameters exist, use defaults
+  if (exists("par") == FALSE){ 
+    for (default_v in 1:length(default_par)){ 
+      assign(names(default_par)[default_v], default_par[[default_v]])
+    }
+  } else {
+    
+    # define user-defined variables
+    for (v in 1:length(par)){ assign(names(par)[v], par[[v]]) }
+    
+    # find which labels have not been user-defined and use defaults
+    undefined_par = names(default_par)[!names(default_par) %in% names(par)]
+    use_defaults = default_par[undefined_par]
+    for (default_v in 1:length(use_defaults)){
+      assign(names(use_defaults)[default_v], use_defaults[[default_v]])
+      }
+  }
   
   # find the size of the RP
   xdim   = nrow(RP)

--- a/R/plotRP.R
+++ b/R/plotRP.R
@@ -81,7 +81,7 @@ plotRP <- function(RP, par){
        font = 2)
   
   # add recurrent points to the plot
-  matpoints(ind[,1], ind[,2],  cex = pcex, col = point_col, pch = pch) 
+  matpoints(ind[,1], ind[,2], cex = as.numeric(pcex), col = point_col, pch = as.numeric(pch))
   
   # add x- and y-axis labels to the plot (so they're not too far away)
   mtext(labelx, at = mean(tstamp), side = 1, line = 1.1, cex = 1.2, font = 2)

--- a/R/plotRP.R
+++ b/R/plotRP.R
@@ -98,6 +98,7 @@ plotRP <- function(RP, par){
   
   # create variable to save plot
   output_plot = recordPlot()
+  invisible(dev.off())
   
   # return the plot
   return(output_plot)


### PR DESCRIPTION
Hi, there,

This PR would expand functionality for `plotRP`, the function that builds and displays recurrence plots, while retaining backwards-compatibility. It includes the following updates:

1. Users may now define a main title, change the style of plot points, and opt to show tickmarks on the _x_- and _y_-axes. 
1. If users define only a subset of parameters, defaults will be supplied for the remaining.
1. The RP is output as an object, allowing users to call it without rebuilding it every time. If the plot is saved to a variable, the displaying of the plot will be suppressed.
1. Documentation for each parameter has been expanded.

Thanks!

Cheers,
Alex