### PR TITLE
Use optimized and user-specified values in optimizeParam

### DIFF
--- a/R/optimizeParam.R
+++ b/R/optimizeParam.R
@@ -129,7 +129,7 @@ optimizeParam <- function(ts1, ts2, par, min.rec = 2, max.rec = 5){
     ## rt	 escape factor = leave it default
     ## eps	 neighborhood diameter = leave default
     
-    embdts1 = false.nearest(ts1, m = 20, d = del, t = 0, rt = 10,
+    embdts1 = false.nearest(ts1, m = maxEmb, d = del, t = 0, rt = 10,
                             eps = sd(ts1)/10)
     
     ## get a percentage of reduction of false neighbours
@@ -156,7 +156,7 @@ optimizeParam <- function(ts1, ts2, par, min.rec = 2, max.rec = 5){
     ## at the moment the method is commented.
     # embmints1 = as.numeric( which(fnnfraction1 == min(fnnfraction1)))
     
-    embdts2 = false.nearest(ts2, m = 20, d = del, t = 0, rt=10,
+    embdts2 = false.nearest(ts2, m = maxEmb, d = del, t = 0, rt=10,
                             eps=sd(ts2)/10)
     
     fnnfraction2 = embdts2[1,]

--- a/R/optimizeParam.R
+++ b/R/optimizeParam.R
@@ -1,5 +1,6 @@
 ## GNU > 2 License:
 ## written by Moreno I. Coco (moreno.cocoi@gmail.com) and James Dixon
+## Additional contributions by Alexandra Paxton
 
 ## Iterative procedure exploring a combination of parameter values
 ## to obtain maximal recurrence between two time-series

--- a/R/optimizeParam.R
+++ b/R/optimizeParam.R
@@ -129,7 +129,7 @@ optimizeParam <- function(ts1, ts2, par, min.rec = 2, max.rec = 5){
     ## rt	 escape factor = leave it default
     ## eps	 neighborhood diameter = leave default
     
-    embdts1 = false.nearest(ts1, m = 20, d = 1, t = 0, rt = 10,
+    embdts1 = false.nearest(ts1, m = 20, d = del, t = 0, rt = 10,
                             eps = sd(ts1)/10)
     
     ## get a percentage of reduction of false neighbours
@@ -156,7 +156,7 @@ optimizeParam <- function(ts1, ts2, par, min.rec = 2, max.rec = 5){
     ## at the moment the method is commented.
     # embmints1 = as.numeric( which(fnnfraction1 == min(fnnfraction1)))
     
-    embdts2 = false.nearest(ts2, m = 20, d = 1, t = 0, rt=10,
+    embdts2 = false.nearest(ts2, m = 20, d = del, t = 0, rt=10,
                             eps=sd(ts2)/10)
     
     fnnfraction2 = embdts2[1,]


### PR DESCRIPTION
Hi there,

This addresses the concerns raised in issue #17 by using the identified optimal delay (commit c2530a239e0642c79f13b07ebd8dcef3f993cb4d) and the user-specified maximum embedding dimension (commit cd4524f870e13daf850c90373d1a19e175cdd361) when identifying the optimal embedding dimension.

Let me know if you see any problems or would like additional edits before merging. I'm hoping that this can be merged fairly quickly, since the `optimizeParam()` function is a great resource for users in this community. Thanks!

Cheers,
Alex