### PR TITLE
Update crqa_helpers.R

### DIFF
--- a/R/crqa_helpers.R
+++ b/R/crqa_helpers.R
@@ -480,7 +480,7 @@ tt <- function(x, minvertline, whiteline){
   
   
   t = sort(z1-z0);
-  t1 = t[which(t-1 > 0)]
+  t1 = t[t >= minvertline)]
   
   TT = mean(t1) ## trapping time
   


### PR DESCRIPTION
Change to make sure the TT calculation only includes vertical lines longer than the minvertline threshold, as per the definition in the literature.